### PR TITLE
修复 route下 import 错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.idea
+/.vscode
+*.log
+.env

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ThinkPHP restfulapi
 
 基于ThinkPHP5.1* 基础上开发的一个简单的restful api ，带权限验证等
 
-> ThinkPHP5.1的运行环境要求PHPPHP7.2+以上。
+> ThinkPHP5.1的运行环境要求PHP版本 5.6.0 以上。
 
 详细开发文档参考 [ThinkPHP5完全开发手册](https://www.kancloud.cn/manual/thinkphp5_1/353946)
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "topthink/framework": "5.1.*"
+        "topthink/framework": "5.1.*",
+      "ext-curl": "*",
+      "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/route/route.php
+++ b/route/route.php
@@ -8,13 +8,15 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-use think\Route;
-//一般路由规则，访问的url为：v1/address/1,对应的文件为Address类下的read方法
-Route::get(':version/address/:id','api/:version.user/address');
 
-Route::resource(':version/user','api/:version.user');       //资源路由，详情查看tp手册资源路由一章
+use think\facade\Route;
+
+//一般路由规则，访问的url为：v1/address/1,对应的文件为Address类下的read方法
+Route::get(':version/address/:id', 'api/:version.user/address');
+
+Route::resource(':version/user', 'api/:version.user');       //资源路由，详情查看tp手册资源路由一章
 
 //生成access_token，post访问Token类下的token方法
-Route::post(':version/token','api/:version.token/token');
-Route::post(':version/token/refresh','api/:version.token/refresh');
+Route::post(':version/token', 'api/:version.token/token');
+Route::post(':version/token/refresh', 'api/:version.token/refresh');
 


### PR DESCRIPTION
修改了readme的说明 think5.1里composer.json php 版本是 5.6.0 

```json
"require": {
        "php": ">=5.6.0",
        "topthink/framework": "5.1.*",
      "ext-curl": "*",
      "ext-json": "*"
 },
```

route 目录下的 route.php 导入的应该是 think\facade\Route;

